### PR TITLE
Dashboard enhancements and fixes (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+[v1.5.0] - 17/06/26
+### ✨ Features & Enhancements
+- Wiki: internal note links now scroll to the target note within the wiki, or open it in the editor when it lives elsewhere.
+- Wiki: resource and note links are prefixed with type icons (video, audio, PDF, generic file) using Font Awesome with an emoji fallback.
+- Wiki: checkbox toggles in a rendered note are saved back to the source note.
+- Wiki: the reading area flows to the available width, with wide elements scrolling inside their own box.
+- Timeline: opens centered on today, re-measures on resize, and clicking a task row scrolls its bar into view (useful for overdue tasks before today).
+- Dashboard: switching tabs preserves each view's scroll position and state, resetting only when the dashboard is reopened from a hidden state.
+- Dashboard: the sort, urgency, and project controls are disabled in views where they have no effect, and the sort labels were decluttered.
+- Subtasks: the nested completion cascade is reflected instantly across all views, and the Edit dialog marks completed subtasks.
+- The task title is now editable in the GUI Edit dialog.
+- Urgency levels are centralized (High/Medium/Low), removing the leftover "normal" level.
+
+### 🐛 Bug Fixes
+- Subtask completion is preserved through GUI edits and dependency-driven rescheduling, which previously reset checkboxes and flattened nesting.
+- Re-nesting in the dialog normalizes the hierarchy, so a completed parent above an incomplete child is cleared.
+- The Kanban "Expand Subtasks" overlay no longer passes clicks through to cards behind it or hijacks card drag.
+- Rendering wiki note links no longer floods the console with "No such resource" errors.
+- Sorting is deterministic, so toggling a subtask no longer reshuffles cards.
+
 [v1.4.0] - 16/06/26
 ### ✨ Features & Enhancements
 - Reworked the Timeline into a professional, interactive Gantt chart.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GPL V2 License](https://img.shields.io/badge/License-GPL_V2-blue.svg)](LICENSE)
 
-An advanced project management plugin for Joplin that transforms your notes into a powerful, visual, and interactive task dashboard. Organize, track, and manage your projects with Kanban, Timeline, and List views, all seamlessly integrated within the Joplin environment.
+An advanced project management plugin for Joplin that turns your notes into a visual, interactive task dashboard. Organize, track, and manage your projects with Kanban, Timeline (Gantt), List, and Wiki views, all integrated within Joplin.
 
 ![Plugin Screenshot](https://github.com/Scrayil/joplin-plugin-projects/blob/main/assets/promo.png)
 
@@ -11,13 +11,14 @@ An advanced project management plugin for Joplin that transforms your notes into
 - **Project-Based Organization**: Group your notes and tasks into distinct projects, each with its own folder structure.
 - **Multiple Views**: Switch between different perspectives to manage your work effectively:
   - **Kanban Board**: A drag-and-drop interface to move tasks between "To Do", "In Progress", and "Done" columns.
-  - **Timeline View**: A chronological, Gantt-style chart that visualizes task durations and deadlines.
-  - **List View**: A clean, sortable table of all your tasks, prioritized by due date and urgency.
-  - **Wiki View**: Browse and read project documentation with rich Markdown support.
+  - **Timeline View**: An interactive Gantt chart with task dependencies, drag-to-reschedule, critical-path highlighting, and milestones.
+  - **List View**: A clean table of all your tasks, ordered by the sort criterion you choose.
+  - **Wiki View**: Browse and read project documentation with Markdown support, type-aware resource icons, and an inline media player.
 - **Interactive Dashboard**: A central hub to visualize and interact with all your tasks from every project.
 - **Urgency Filter**: A dedicated toggle (🚨) to instantly filter the view and show only Overdue or Approaching tasks.
 - **Smart Task Recognition**: Any to-do note inside a project's dedicated "Tasks" folder is automatically picked up by the dashboard.
-- **Sub-task Management**: Create, nest, and toggle sub-tasks (markdown checkboxes) using a collapsible tree view directly from the Kanban board or edit dialog. Includes a dedicated Fullscreen mode for managing complex hierarchies.
+- **Sub-task Management**: Build and nest sub-tasks (markdown checkboxes) with drag & drop in the New / Edit Task dialog, and toggle them straight from the Kanban cards, with cascading logic that updates the whole hierarchy instantly. A read-only Fullscreen overlay lets you inspect deep hierarchies.
+- **Task Dependencies & Scheduling**: Give tasks a start date and link them with FS/SS/FF/SF dependencies, then visualize and reschedule everything on the Gantt timeline, with critical-path analysis per project.
 - **Seamless Integration**: Uses Joplin's native to-dos, tags, and folders. Your data remains in the standard Joplin format.
 - **Automatic Sync**: The dashboard stays in sync with your notes in real-time.
 
@@ -60,28 +61,33 @@ The dashboard is the heart of the plugin and provides several ways to look at yo
 - **Visualize Workflow**: See all your tasks as cards in "To Do", "In Progress", and "Done" columns.
 - **Update Status**: Simply drag and drop a card from one column to another to update its status. Moving a task to "In Progress" adds an `In Progress` tag. Moving it to "Done" marks the to-do as completed and checks off all its sub-tasks.
 - **Interactions**:
-  - **Double-Click**: Opens an edit dialog to change priority, due date, and sub-tasks.
-  - **Right-Click**: Opens a context menu to Edit, Open Note, or Delete.
-  - **Check Sub-tasks**: Expand, collapse, and toggle nested sub-tasks directly from the card.
-  - **Fullscreen Subtasks**: Open subtasks in a large overlay for easier management of deep hierarchies.
+  - **Double-Click**: Opens an edit dialog to change the title, start and due dates, priority, and sub-tasks.
+  - **Right-Click**: Opens a context menu to Edit (GUI), Edit Text (Note), Delete, or Expand Subtasks.
+  - **Check Sub-tasks**: Expand, collapse, and toggle nested sub-tasks directly from the card; checking a parent completes its descendants, while unchecking a child clears its parents, all reflected instantly.
+  - **Fullscreen Subtasks**: Open the sub-task tree in a large read-only overlay to inspect deep hierarchies.
 
-#### Timeline View
-- **Visualize Deadlines**: See tasks plotted on a timeline based on their creation date and due date. A red line indicates the current day.
-- **Identify Overlaps**: Quickly see which tasks are running in parallel.
-- **Interactions**: Double-click to edit, Right-click for context menu.
+#### Timeline View (Gantt)
+- **Visualize Schedules**: Each task is drawn as a bar from its start date to its due date, grouped by project. A red line indicates the current day.
+- **Reschedule by Dragging**: Drag a bar to move it, or drag its edges to resize it. The task's start and due dates update instantly.
+- **Dependencies**: Drag from a bar's start/end handle onto another task to link them. The dependency type (FS, SS, FF, SF) is derived from the connected handles; cross-project links and cycles are prevented.
+- **Critical Path**: Toggle the critical-path view to highlight the longest chain of linked tasks per project.
+- **Milestones**: Zero-duration tasks (same start and due date) are rendered as milestone diamonds.
+- **Progress**: Each bar is filled in proportion to the share of completed sub-tasks, with the percentage shown inside the bar (tasks without sub-tasks show no fill).
+- **Navigation**: The timeline opens centered on today. Jump to the first task, today, or the last task, zoom between Month, Week, and Day scales, and click a task row to scroll its bar into view (useful for overdue tasks sitting before today).
+- **Interactions**: Double-click to edit, Right-click for the context menu.
 
 #### List View
-- **Get a Quick Overview**: A simple, powerful table showing all your active tasks.
-- **Smart Sorting**: Tasks are automatically sorted by:
-  1.  Due Date (most urgent first).
-  2.  Priority (`High` > `Normal` > `Low`).
-  3.  Creation Date (oldest first).
+- **Get a Quick Overview**: A simple table showing all your active tasks.
+- **Flexible Sorting**: Choose the order from the header `Sort` dropdown: Due Date, Start Date, Priority (`High` 🔴 > `Medium` 🟠 > `Low` 🔵), or Created Time. The chosen criterion applies consistently across the Kanban, Timeline, and List views.
 - **Interactions**: Double-click to edit, Right-click for context menu.
 
 #### Wiki View
 - **Integrated Knowledge Base**: Browse and read project documentation directly within the dashboard.
 - **Rich Rendering**: Full support for standard Markdown, including **Tables**, **Task Lists**, and syntax-highlighted **Code Snippets**.
-- **Adaptive Interface**: Features a collapsible Table of Contents sidebar and a responsive reader that adapts to your theme (Light/Dark).
+- **Internal Links & Resource Icons**: Links to other notes scroll straight to them within the Wiki (or open them in the editor when they live elsewhere), and attachment links are prefixed with a type icon (video, audio, PDF, or generic file).
+- **Inline Media**: Video and audio attachments open in an embedded player without leaving the dashboard.
+- **Live Checkboxes**: Ticking a checkbox in a rendered note is saved back to the source note.
+- **Adaptive Interface**: Features a collapsible Table of Contents sidebar and a responsive reader whose width adapts fluidly to the available space and to your theme (Light/Dark).
 - **Offline Ready**: All rendering and highlighting libraries are bundled, ensuring full functionality even without an internet connection.
 
 ### Urgency & Deadlines

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joplin-plugin-projects",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joplin-plugin-projects",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "GPL-2.0",
       "dependencies": {
         "@hello-pangea/dnd": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-projects",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "scripts": {
     "dist": "webpack --env joplin-plugin-config=buildMain && webpack --env joplin-plugin-config=buildExtraScripts && webpack --env joplin-plugin-config=createArchive",
     "prepare": "npm run dist",

--- a/src/gui/TaskDashboard.ts
+++ b/src/gui/TaskDashboard.ts
@@ -90,7 +90,10 @@ export class TaskDashboard {
                 if (message.name === 'toggleSubTask') {
                     return await this.toggleSubTask(message.payload);
                 }
-                
+                if (message.name === 'toggleWikiCheckbox') {
+                    return await this.toggleWikiCheckbox(message.payload);
+                }
+
                 if (['openNote', 'toggleSideBar', 'toggleNoteList', 'synchronize', 'toggleMenuBar', 'resetLayout'].includes(message.name)) {
                      const commandArgs = message.payload?.taskId ? [message.payload.taskId] : [];
                      await joplin.commands.execute(message.name, ...commandArgs);
@@ -150,11 +153,20 @@ export class TaskDashboard {
     }
 
     /**
+     * Signals the webview to reset its view state, so reopening the dashboard from a fully
+     * hidden state starts on a clean view rather than restoring the previous scroll and tab.
+     */
+    private async notifyDashboardReset() {
+        await joplin.views.panels.postMessage(this.panelHandle, { name: 'dashboardReset' });
+    }
+
+    /**
      * Makes the dashboard panel visible if it is currently hidden.
      */
     public async show() {
         if (await joplin.views.panels.visible(this.panelHandle)) return;
         await joplin.views.panels.show(this.panelHandle);
+        await this.notifyDashboardReset();
     }
 
     /**
@@ -163,6 +175,9 @@ export class TaskDashboard {
     public async toggle() {
         const isVisible = await joplin.views.panels.visible(this.panelHandle);
         await joplin.views.panels.show(this.panelHandle, !isVisible);
+        if (!isVisible) {
+            await this.notifyDashboardReset();
+        }
     }
 
     /**
@@ -175,6 +190,11 @@ export class TaskDashboard {
             if (result) {
                 if (result.action === 'save') {
                     const formData = result.data;
+                    const title = (formData.taskTitle || '').trim();
+                    if (!title) {
+                        await joplin.views.dialogs.showToast({ message: "Task title required", duration: 3000, type: ToastType.Error });
+                        return;
+                    }
                     const urgency = formData.taskUrgency;
                     const dueDateStr = formData.taskDueDate;
                     let dueDate = dueDateStr ? new Date(dueDateStr).getTime() : 0;
@@ -195,7 +215,7 @@ export class TaskDashboard {
                         .map((s: string) => s.replace(/\s+$/, ''))
                         .filter((s: string) => s.trim().length > 0);
 
-                    await this.updateTask(task.id, { subTasks, urgency, dueDate, startDate });
+                    await this.updateTask(task.id, { title, subTasks, urgency, dueDate, startDate });
                 } else if (result.action === 'delete') {
                     await this.handleDeleteTaskWithConfirmation(task);
                 } else if (result.action === 'text_edit') {
@@ -240,10 +260,10 @@ export class TaskDashboard {
 
         const formData = await newTaskDialog(defaultProjectId);
         if (formData) {
-            const title = formData.taskTitle;
+            const title = (formData.taskTitle || '').trim();
             const projectId = formData.taskProject;
-            
-            if (!title || title.trim().length === 0) {
+
+            if (!title) {
                 await joplin.views.dialogs.showToast({ message: "Task title required", duration: 3000, type: ToastType.Error });
                 return;
             }
@@ -306,11 +326,7 @@ export class TaskDashboard {
                 await updateNote(note.id, updates);
             }
 
-            if (payload.urgency && payload.urgency !== Config.TAGS.KEYWORDS.NORMAL) {
-                await this.tagService.updatePriorityTags(note.id, payload.urgency);
-            } else {
-                 await this.tagService.updatePriorityTags(note.id, 'medium');
-            }
+            await this.tagService.updatePriorityTags(note.id, payload.urgency || Config.TAGS.KEYWORDS.MEDIUM);
             
             await joplin.views.dialogs.showToast({ message: "Task created successfully!", duration: 3000, type: ToastType.Success });
             return { success: true };
@@ -323,9 +339,9 @@ export class TaskDashboard {
     }
 
     /**
-     * Updates an existing task's body (subtasks), due date, and urgency tags.
+     * Updates an existing task's title, body (subtasks), due date, and urgency tags.
      */
-    private async updateTask(taskId: string, payload: { subTasks: string[]; urgency: string; dueDate: number; startDate?: number }) {
+    private async updateTask(taskId: string, payload: { title?: string; subTasks: string[]; urgency: string; dueDate: number; startDate?: number }) {
         try {
             // Retrieve existing body to merge updates without data loss
             const currentNote = await getNote(taskId, ['body', 'application_data']);
@@ -350,11 +366,15 @@ export class TaskDashboard {
                 delete appData['joplin-plugin-projects'].startDate;
             }
 
-            await updateNote(taskId, { 
+            const updates: any = {
                 body: body,
                 todo_due: payload.dueDate,
                 application_data: JSON.stringify(appData)
-            });
+            };
+            if (payload.title && payload.title.trim().length > 0) {
+                updates.title = payload.title.trim();
+            }
+            await updateNote(taskId, updates);
 
             await this.tagService.updatePriorityTags(taskId, payload.urgency);
 
@@ -442,9 +462,10 @@ export class TaskDashboard {
             visited.add(targetTask.id);
 
             await this.updateTask(targetTask.id, {
-                // updateTask expects string[]; only the titles are needed to rebuild the markdown.
-                subTasks: targetTask.subTasks.map((st: any) => st.title),
-                urgency: targetTask.tags.find((t: string) => ['high','medium','normal','low'].includes(t.toLowerCase())) || 'normal',
+                // The full subtask objects are forwarded so their completion state and nesting
+                // level are preserved when the markdown body is rebuilt.
+                subTasks: targetTask.subTasks,
+                urgency: targetTask.tags.find((t: string) => ['high','medium','low'].includes(t.toLowerCase())) || Config.TAGS.KEYWORDS.MEDIUM,
                 dueDate: newTargetDue,
                 startDate: newTargetStart
             });
@@ -531,6 +552,23 @@ export class TaskDashboard {
         
         if (newBody !== note.body) {
             await updateNote(payload.taskId, { body: newBody });
+        }
+
+        return { success: true };
+    }
+
+    /**
+     * Toggles a single plain checkbox by index within any note body, used by the Wiki
+     * reader for note checklists that are not task subtasks, then refreshes the dashboard.
+     */
+    private async toggleWikiCheckbox(payload: { noteId: string, index: number, checked: boolean }) {
+        const note = await getNote(payload.noteId, ['body']);
+        const newBody = this.noteParser.toggleCheckboxAt(note.body, payload.index, payload.checked);
+
+        if (newBody !== note.body) {
+            await updateNote(payload.noteId, { body: newBody });
+            this.projectService.invalidateCache();
+            await joplin.views.panels.postMessage(this.panelHandle, { name: 'dataChanged' });
         }
 
         return { success: true };

--- a/src/gui/assets/css/new_task_dialog_content_style.css
+++ b/src/gui/assets/css/new_task_dialog_content_style.css
@@ -224,6 +224,21 @@ select:disabled {
     border: 1px solid var(--joplin-divider-color);
 }
 
+/* Completed subtasks are dimmed and struck through so their status is obvious while
+   reordering the list, with a leading check mark left intact for quick scanning. */
+.subtask-item.completed .subtask-title {
+    text-decoration: line-through;
+    opacity: 0.6;
+}
+
+.subtask-done-mark {
+    flex-shrink: 0;
+    margin-right: 6px;
+    font-weight: bold;
+    color: var(--joplin-color-correct, #6aab73);
+    opacity: 0.8;
+}
+
 .subtask-item.empty {
     display: flex;
     color: transparent;

--- a/src/gui/assets/html/new_task_dialog_content.html
+++ b/src/gui/assets/html/new_task_dialog_content.html
@@ -28,9 +28,7 @@
             <div class="form-group third">
                 <label for="taskUrgency">Urgency</label>
                 <select id="taskUrgency" name="taskUrgency" class="form-control">
-                    <option value="high">🔴 High</option>
-                    <option value="normal" selected>🟠 Normal</option>
-                    <option value="low">🔵 Low</option>
+                    <!-- Urgency options are injected from Config.TAGS to stay consistent with the tag names -->
                 </select>
             </div>
         </div>

--- a/src/gui/assets/js/new_task_dialog_content_script.js
+++ b/src/gui/assets/js/new_task_dialog_content_script.js
@@ -133,7 +133,8 @@
     function serialize() {
         const lines = subTasks.map(t => {
             const indent = '  '.repeat(t.level || 0);
-            return `${indent}- [ ] ${t.title}`;
+            const mark = t.completed ? 'x' : ' ';
+            return `${indent}- [${mark}] ${t.title}`;
         });
         hiddenInput.value = lines.join('\n');
     }
@@ -142,7 +143,7 @@
         const lines = hiddenInput.value.split('\n');
         lines.forEach(line => {
             if (!line.trim()) return;
-            const match = line.match(/^(\s*)(?:-\s*\[[ xX]\]\s*)?(.*)$/);
+            const match = line.match(/^(\s*)(?:-\s*\[([ xX])\]\s*)?(.*)$/);
             if (match) {
                 const rawIndent = match[1];
                 let level = 0;
@@ -150,11 +151,13 @@
                 if (rawIndent.includes('\t')) level = rawIndent.length;
                 else level = Math.floor(rawIndent.length / 2);
 
-                let title = match[2].trim();
+                const completed = (match[2] || '').toLowerCase() === 'x';
+
+                let title = match[3].trim();
                 // Legacy cleanup
                 if (title.startsWith('- [')) title = title.replace(/^-\s*\[[ xX]\]\s*/, '');
 
-                subTasks.push({ id: uuid(), title: title, level: level });
+                subTasks.push({ id: uuid(), title: title, level: level, completed: completed });
             }
         });
     }
@@ -439,7 +442,16 @@
             dragHandle.textContent = '⋮⋮';
             dropTarget.appendChild(dragHandle);
 
+            if (node.completed) {
+                dropTarget.classList.add('completed');
+                const doneMark = document.createElement('span');
+                doneMark.className = 'subtask-done-mark';
+                doneMark.textContent = '✓';
+                dropTarget.appendChild(doneMark);
+            }
+
             const span = document.createElement('span');
+            span.className = 'subtask-title';
             span.textContent = node.title;
             span.title = node.title;
             span.style.flex = '1';

--- a/src/gui/dialogs.ts
+++ b/src/gui/dialogs.ts
@@ -12,6 +12,24 @@ const logger = Logger.create('Projects: Index');
 const HANDLES = {}
 
 /**
+ * Builds the urgency option markup from the central tag configuration so the dialog
+ * labels always match the tag names used everywhere else, marking the given keyword as
+ * the selected option.
+ * @param selected The urgency keyword to pre-select.
+ * @returns The concatenated option elements.
+ */
+function buildUrgencyOptions(selected: string): string {
+    const levels = [
+        { value: Config.TAGS.KEYWORDS.HIGH, label: Config.TAGS.HIGH },
+        { value: Config.TAGS.KEYWORDS.MEDIUM, label: Config.TAGS.MEDIUM },
+        { value: Config.TAGS.KEYWORDS.LOW, label: Config.TAGS.LOW }
+    ];
+    return levels
+        .map(l => `<option value="${l.value}"${l.value === selected ? ' selected' : ''}>${l.label}</option>`)
+        .join('');
+}
+
+/**
  * Displays the dialog for creating a new project.
  * Handles user input and invokes the project creation logic.
  */
@@ -92,6 +110,7 @@ export async function newTaskDialog(defaultProjectId?: string) {
     }
     
     html = html.replace('<!-- Options will be injected via JS or dynamically generated HTML -->', optionsHtml);
+    html = html.replace('<!-- Urgency options are injected from Config.TAGS to stay consistent with the tag names -->', buildUrgencyOptions(Config.TAGS.KEYWORDS.MEDIUM));
 
     await joplin.views.dialogs.setHtml(dialog, html);
 
@@ -140,7 +159,7 @@ export async function editTaskDialog(task: any) {
 
     html = html.replace('<h1>New Task</h1>', '<h1>Edit Task</h1>');
 
-    html = html.replace('id="taskTitle" name="taskTitle"', `id="taskTitle" name="taskTitle" value="${task.title}" disabled`);
+    html = html.replace('id="taskTitle" name="taskTitle"', `id="taskTitle" name="taskTitle" value="${task.title.replace(/"/g, '&quot;')}"`);
 
     const projectOptions = `<option value="${task.projectId}" selected>${task.projectName}</option>`;
     html = html.replace('id="taskProject" name="taskProject"', `id="taskProject" name="taskProject" disabled`);
@@ -163,20 +182,14 @@ export async function editTaskDialog(task: any) {
         html = html.replace('id="taskStartDate" name="taskStartDate"', `id="taskStartDate" name="taskStartDate" value="${isoStr}"`);
     }
 
-    const urgency = task.tags.find((t: string) => t.toLowerCase().includes('high')) ? 'high' :
-                    (task.tags.find((t: string) => t.toLowerCase().includes('low')) ? 'low' : 'normal');
-    
-    if (urgency === 'high') {
-        html = html.replace('value="high"', 'value="high" selected');
-        html = html.replace('value="normal" selected', 'value="normal"');
-    } else if (urgency === 'low') {
-        html = html.replace('value="low"', 'value="low" selected');
-        html = html.replace('value="normal" selected', 'value="normal"');
-    }
+    const urgency = task.tags.find((t: string) => t.toLowerCase().includes('high')) ? Config.TAGS.KEYWORDS.HIGH :
+                    (task.tags.find((t: string) => t.toLowerCase().includes('low')) ? Config.TAGS.KEYWORDS.LOW : Config.TAGS.KEYWORDS.MEDIUM);
+
+    html = html.replace('<!-- Urgency options are injected from Config.TAGS to stay consistent with the tag names -->', buildUrgencyOptions(urgency));
 
     // Subtasks are passed through a hidden input that the dialog script reads;
     // double quotes are escaped to keep the value attribute well-formed.
-    const subTasksStr = task.subTasks.map((st: any) => '  '.repeat(st.level || 0) + st.title).join('\n');
+    const subTasksStr = task.subTasks.map((st: any) => `${'  '.repeat(st.level || 0)}- [${st.completed ? 'x' : ' '}] ${st.title}`).join('\n');
     html = html.replace('id="taskSubTasks" name="taskSubTasks" value=""', `id="taskSubTasks" name="taskSubTasks" value="${subTasksStr.replace(/"/g, '&quot;')}"`);
 
     await joplin.views.dialogs.setHtml(dialog, html);

--- a/src/gui/react/App.tsx
+++ b/src/gui/react/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useState, useEffect } from 'react';
-import { Task, DashboardData } from './types';
+import { Task, DashboardData, SubTask } from './types';
 import KanbanBoard from './components/KanbanBoard';
 import TimelineView from './components/TimelineView';
 import ListView from './components/ListView';
@@ -9,11 +9,55 @@ import WikiView from './components/WikiView';
 import { getPriorityValue } from './utils';
 
 /**
+ * Applies the nested completion cascade for a single subtask toggle, mirroring the backend
+ * so optimistic updates match the persisted result. Checking a subtask completes every
+ * deeper-nested descendant that follows it; unchecking a subtask clears the completion of
+ * each shallower ancestor up to the root, since a parent cannot stay complete while a child
+ * is incomplete. The input array is not mutated.
+ * @param subTasks The current subtasks in document order, carrying their nesting level.
+ * @param targetIndex The index of the toggled subtask.
+ * @param checked The new completion state of the toggled subtask.
+ * @returns A new subtasks array with the cascade applied.
+ */
+const cascadeSubTaskCompletion = (subTasks: SubTask[], targetIndex: number, checked: boolean): SubTask[] => {
+    const next = subTasks.map(st => ({ ...st }));
+    if (targetIndex < 0 || targetIndex >= next.length) return next;
+
+    next[targetIndex].completed = checked;
+
+    if (checked) {
+        for (let i = targetIndex + 1; i < next.length; i++) {
+            if (next[i].level > next[targetIndex].level) next[i].completed = true;
+            else break;
+        }
+    } else {
+        let currentLevel = next[targetIndex].level;
+        let currentIndex = targetIndex;
+        while (currentLevel > 0) {
+            let parentIndex = -1;
+            for (let i = currentIndex - 1; i >= 0; i--) {
+                if (next[i].level < currentLevel) { parentIndex = i; break; }
+            }
+            if (parentIndex === -1) break;
+            next[parentIndex].completed = false;
+            currentIndex = parentIndex;
+            currentLevel = next[parentIndex].level;
+        }
+    }
+
+    return next;
+};
+
+/**
  * Main application component for the Task Dashboard.
  * Manages state, data fetching, and tab switching.
  */
 const App: React.FC = () => {
     const [activeTab, setActiveTab] = useState<'kanban' | 'timeline' | 'table' | 'wiki' | 'info'>('kanban');
+    // Bumped when the dashboard is reopened from a fully hidden state, forcing the view
+    // subtree to remount so each view starts clean; switching tabs keeps the views mounted
+    // and therefore preserves their scroll position and internal state.
+    const [viewSessionKey, setViewSessionKey] = useState(0);
     const [data, setData] = useState<DashboardData>({ projects: [], tasks: [] });
     const [loading, setLoading] = useState(true);
     const [projectFilter, setProjectFilter] = useState<string>('all');
@@ -118,6 +162,9 @@ const App: React.FC = () => {
                 if (message.name === 'dataChanged') {
                     fetchData();
                     updateTheme();
+                } else if (message.name === 'dashboardReset') {
+                    setActiveTab('kanban');
+                    setViewSessionKey(k => k + 1);
                 }
             });
         }
@@ -237,7 +284,10 @@ const App: React.FC = () => {
 
     /**
      * Optimistically updates the completion state of a single subtask in local state,
-     * then persists the change to the backend and refetches on failure.
+     * then persists the change to the backend and refetches on failure. The same nesting
+     * cascade the backend applies is mirrored here so the change is reflected in real time:
+     * checking a subtask completes all of its descendants, while unchecking one clears the
+     * completion of its ancestors up to the root.
      * @param taskId The ID of the task that owns the subtask.
      * @param subTaskIndex The index of the subtask within the task.
      * @param checked The new completion state.
@@ -245,9 +295,7 @@ const App: React.FC = () => {
     const handleToggleSubTask = async (taskId: string, subTaskIndex: number, checked: boolean) => {
         const current = mergedTasks.find(t => t.id === taskId);
         if (!current) return;
-        const newSubTasks = current.subTasks.map((st, i) =>
-            i === subTaskIndex ? { ...st, completed: checked } : st
-        );
+        const newSubTasks = cascadeSubTaskCompletion(current.subTasks, subTaskIndex, checked);
         applyOptimistic(taskId, { subTasks: newSubTasks });
 
         try {
@@ -257,6 +305,7 @@ const App: React.FC = () => {
             fetchData();
         }
     };
+
 
     /**
      * Opens the note backing a task in the Joplin editor.
@@ -320,30 +369,43 @@ const App: React.FC = () => {
             });
         }
         
-        return tasks.sort((a, b) => {
+        // Sorting operates on a copy so the memoized merged list is never mutated, and every
+        // branch ends with a stable tie-break on the task ID. This keeps the order fully
+        // deterministic regardless of the order in which the backend returns tasks, so an
+        // action that merely rewrites a note (e.g. toggling a subtask) never reshuffles cards
+        // that compare equal on the active sort key.
+        return [...tasks].sort((a, b) => {
             if (sortOption === 'dueDate') {
                 const dateA = a.dueDate ? a.dueDate : Number.MAX_VALUE;
                 const dateB = b.dueDate ? b.dueDate : Number.MAX_VALUE;
                 if (dateA !== dateB) return dateA - dateB;
-                return getPriorityValue(a.tags) - getPriorityValue(b.tags);
+                return (getPriorityValue(a.tags) - getPriorityValue(b.tags)) || a.id.localeCompare(b.id);
             } else if (sortOption === 'startDate') {
                 const startA = a.startDate || a.createdTime;
                 const startB = b.startDate || b.createdTime;
                 if (startA !== startB) return startA - startB;
-                return (a.dueDate || Number.MAX_VALUE) - (b.dueDate || Number.MAX_VALUE);
+                return ((a.dueDate || Number.MAX_VALUE) - (b.dueDate || Number.MAX_VALUE)) || a.id.localeCompare(b.id);
             } else if (sortOption === 'priority') {
                 const prioA = getPriorityValue(a.tags);
                 const prioB = getPriorityValue(b.tags);
                 if (prioA !== prioB) return prioA - prioB;
-                return (a.dueDate || Number.MAX_VALUE) - (b.dueDate || Number.MAX_VALUE);
+                return ((a.dueDate || Number.MAX_VALUE) - (b.dueDate || Number.MAX_VALUE)) || a.id.localeCompare(b.id);
             } else if (sortOption === 'createdTime') {
-                return b.createdTime - a.createdTime;
+                return (b.createdTime - a.createdTime) || a.id.localeCompare(b.id);
             }
-            return 0;
+            return a.id.localeCompare(b.id);
         });
     }, [mergedTasks, projectFilter, showUrgentOnly, sortOption]);
 
     if (loading) return <div>Loading tasks...</div>;
+
+    // Task-oriented controls have no effect outside the task views: sorting and the urgency
+    // filter are inert in the Wiki and Guide tabs, and the project filter is meaningless in
+    // the Guide tab. They are disabled there and re-enabled automatically on returning to a
+    // view where they apply.
+    const sortDisabled = activeTab === 'wiki' || activeTab === 'info';
+    const urgencyDisabled = activeTab === 'wiki' || activeTab === 'info';
+    const projectFilterDisabled = activeTab === 'info';
 
     return (
         <div className="dashboard-container">
@@ -351,10 +413,13 @@ const App: React.FC = () => {
                 <div className="controls-container">
                     {data.projects.length > 1 ? (
                         <div className="select-wrapper">
-                            <select 
+                            <select
                                 className="project-filter-select"
-                                value={projectFilter} 
+                                value={projectFilter}
                                 onChange={(e) => setProjectFilter(e.target.value)}
+                                disabled={projectFilterDisabled}
+                                style={{ opacity: projectFilterDisabled ? 0.4 : undefined, cursor: projectFilterDisabled ? 'not-allowed' : undefined }}
+                                title={projectFilterDisabled ? 'Project selection is unavailable in this view' : undefined}
                             >
                                 <option value="all">All Tasks</option>
                                 {data.projects.map(p => (
@@ -371,12 +436,14 @@ const App: React.FC = () => {
                             value={sortOption}
                             onChange={(e) => setSortOption(e.target.value)}
                             onClick={() => setSortApplyToken(v => v + 1)}
-                            title="Sort by"
+                            disabled={sortDisabled}
+                            style={{ opacity: sortDisabled ? 0.4 : undefined, cursor: sortDisabled ? 'not-allowed' : undefined }}
+                            title={sortDisabled ? 'Sorting is unavailable in this view' : 'Sort by'}
                         >
-                            <option value="dueDate">Sort by Due Date</option>
-                            <option value="startDate">Sort by Start Date</option>
-                            <option value="priority">Sort by Priority</option>
-                            <option value="createdTime">Sort by Created Time</option>
+                            <option value="dueDate">Due Date</option>
+                            <option value="startDate">Start Date</option>
+                            <option value="priority">Priority</option>
+                            <option value="createdTime">Created Time</option>
                         </select>
                     </div>
                     <button 
@@ -387,16 +454,19 @@ const App: React.FC = () => {
                     >
                         +
                     </button>
-                    <button 
+                    <button
                         className="action-btn"
-                        onClick={() => setShowUrgentOnly(!showUrgentOnly)} 
-                        style={{ 
+                        onClick={() => setShowUrgentOnly(!showUrgentOnly)}
+                        disabled={urgencyDisabled}
+                        style={{
                             fontSize: '1rem',
                             backgroundColor: showUrgentOnly ? 'var(--prj-overdue)' : undefined,
                             color: showUrgentOnly ? 'white' : undefined,
-                            borderColor: showUrgentOnly ? 'var(--prj-overdue)' : undefined
+                            borderColor: showUrgentOnly ? 'var(--prj-overdue)' : undefined,
+                            opacity: urgencyDisabled ? 0.4 : undefined,
+                            cursor: urgencyDisabled ? 'not-allowed' : undefined
                         }}
-                        title="Show only urgent tasks (Overdue & Approaching)"
+                        title={urgencyDisabled ? 'Urgency filter is unavailable in this view' : 'Show only urgent tasks (Overdue & Approaching)'}
                     >
                         🚨
                     </button>
@@ -449,33 +519,48 @@ const App: React.FC = () => {
             </div>
             
             <div className="content">
-                {activeTab === 'kanban' && <KanbanBoard 
-                    tasks={displayedTasks} 
-                    onUpdateStatus={handleUpdateStatus}
-                    onToggleSubTask={handleToggleSubTask}
-                    onOpenNote={handleOpenNote}
-                    onEditTask={handleOpenEditTaskDialog}
-                />}
-                {activeTab === 'timeline' && <TimelineView
-                    tasks={displayedTasks}
-                    sortOption={sortOption}
-                    sortApplyToken={sortApplyToken}
-                    onOpenNote={handleOpenNote}
-                    onEditTask={handleOpenEditTaskDialog}
-                    onUpdateDependencies={handleUpdateDependencies}
-                />}
-                {activeTab === 'table' && <ListView 
-                    tasks={displayedTasks} 
-                    onOpenNote={handleOpenNote} 
-                    onEditTask={handleOpenEditTaskDialog}
-                />}
-                {activeTab === 'wiki' && <WikiView 
-                    projectId={projectFilter}
-                    onOpenNote={handleOpenNote}
-                    onToggleSubTask={handleToggleSubTask}
-                    lastUpdated={lastUpdated}
-                />}
-                {activeTab === 'info' && <InfoView />}
+                {/* All views stay mounted and are shown/hidden via display so that switching
+                    tabs preserves each view's scroll position and internal state. The keyed
+                    wrapper remounts the whole subtree on a dashboard reset (full reopen). */}
+                <div key={viewSessionKey} style={{ height: '100%' }}>
+                    <div style={{ height: '100%', display: activeTab === 'kanban' ? 'block' : 'none' }}>
+                        <KanbanBoard
+                            tasks={displayedTasks}
+                            onUpdateStatus={handleUpdateStatus}
+                            onToggleSubTask={handleToggleSubTask}
+                            onOpenNote={handleOpenNote}
+                            onEditTask={handleOpenEditTaskDialog}
+                        />
+                    </div>
+                    <div style={{ height: '100%', display: activeTab === 'timeline' ? 'block' : 'none' }}>
+                        <TimelineView
+                            tasks={displayedTasks}
+                            sortOption={sortOption}
+                            sortApplyToken={sortApplyToken}
+                            onOpenNote={handleOpenNote}
+                            onEditTask={handleOpenEditTaskDialog}
+                            onUpdateDependencies={handleUpdateDependencies}
+                        />
+                    </div>
+                    <div style={{ height: '100%', display: activeTab === 'table' ? 'block' : 'none' }}>
+                        <ListView
+                            tasks={displayedTasks}
+                            onOpenNote={handleOpenNote}
+                            onEditTask={handleOpenEditTaskDialog}
+                        />
+                    </div>
+                    <div style={{ height: '100%', display: activeTab === 'wiki' ? 'block' : 'none' }}>
+                        <WikiView
+                            projectId={projectFilter}
+                            onOpenNote={handleOpenNote}
+                            lastUpdated={lastUpdated}
+                            isActive={activeTab === 'wiki'}
+                        />
+                    </div>
+                    <div style={{ height: '100%', display: activeTab === 'info' ? 'block' : 'none' }}>
+                        <InfoView />
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/src/gui/react/components/InfoView.tsx
+++ b/src/gui/react/components/InfoView.tsx
@@ -76,17 +76,30 @@ const InfoView: React.FC = () => {
                 <h3 style={{ color: 'var(--text-color)', fontSize: '1.4rem' }}>📋 Views</h3>
                 <ul style={{ paddingLeft: '25px' }}>
                     <li style={{ marginBottom: '12px' }}><strong>Kanban:</strong> Visualize your workflow. Drag and drop cards between "To Do", "In Progress", and "Done". Moving a task to "Done" automatically completes all its sub-tasks.</li>
-                    <li style={{ marginBottom: '12px' }}><strong>Timeline:</strong> A temporal view of your tasks from creation to deadline. The <span style={{color: 'var(--prj-today)', fontWeight: 'bold'}}>red vertical line</span> indicates the current day.</li>
-                    <li style={{ marginBottom: '12px' }}><strong>List:</strong> A professional tabular view of all active tasks, sorted by urgency and due date.</li>
-                    <li style={{ marginBottom: '12px' }}><strong>Wiki:</strong> A fully-featured documentation reader with rich Markdown support.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Timeline (Gantt):</strong> An interactive Gantt chart spanning each task from its start date to its deadline. Reschedule by dragging, link tasks into dependencies, and highlight the critical path. The <span style={{color: 'var(--prj-today)', fontWeight: 'bold'}}>red vertical line</span> marks the current day. See the dedicated section below.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>List:</strong> A professional tabular view of all active tasks, ordered by the active sort criterion.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Wiki:</strong> A documentation reader with Markdown support, type-aware resource icons, and an inline media player.</li>
+                </ul>
+            </section>
+
+            <section style={{ marginBottom: '30px' }}>
+                <h3 style={{ color: 'var(--text-color)', fontSize: '1.4rem' }}>🗓️ Timeline (Gantt)</h3>
+                <p>The Timeline is a full interactive Gantt chart. Each task is drawn as a bar spanning from its <strong>Start Date</strong> to its <strong>Due Date</strong>, grouped by project.</p>
+                <ul style={{ paddingLeft: '25px', marginTop: '10px' }}>
+                    <li style={{ marginBottom: '12px' }}><strong>Reschedule by Dragging:</strong> Drag a bar to move it, or drag its left/right edge to resize it. Both update the task's start and due dates instantly.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Dependencies:</strong> Drag from a bar's start or end handle onto another task to link them. The dependency type (<code>FS</code>, <code>SS</code>, <code>FF</code>, <code>SF</code>) is derived from which handles you connect. Cross-project links and cycles are prevented automatically.</li>
+                    <li style={{ marginBottom: '12px' }}><strong><span style={{ color: 'var(--prj-critical)', fontWeight: 'bold' }}>⬩ Critical Path:</span></strong> Toggle this to highlight the longest chain of linked tasks per project, the sequence that drives the project's end date.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Milestones:</strong> A task whose start and due dates are the same is rendered as a milestone <strong>diamond ◆</strong> instead of a bar.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Progress:</strong> Each bar is partially filled to reflect the task's completion (the share of its sub-tasks that are checked), with the matching percentage shown inside the bar. Tasks without sub-tasks (or with none completed yet) show no fill.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Navigation:</strong> The timeline opens centered on today. Jump with <em>⟸ First Task</em>, <em>⊙ Today</em>, and <em>Last Task ⟹</em>, and use <em>Zoom In/Out</em> to switch between <strong>Month</strong>, <strong>Week</strong>, and <strong>Day</strong> scales. <strong>Click a task row</strong> to scroll its bar into view, useful for reaching overdue tasks whose bars sit before today.</li>
                 </ul>
             </section>
 
             <section style={{ marginBottom: '30px' }}>
                 <h3 style={{ color: 'var(--text-color)', fontSize: '1.4rem' }}>🖱️ Interactions</h3>
                 <ul style={{ paddingLeft: '25px' }}>
-                    <li style={{ marginBottom: '12px' }}><strong>Double Click:</strong> Opens the <strong>Edit Task</strong> dialog to modify deadlines, priority, or sub-tasks.</li>
-                    <li style={{ marginBottom: '12px' }}><strong>Right Click:</strong> Opens a <strong>Context Menu</strong> with options to Edit (GUI), Edit Text (Note), Delete the task, or Expand Subtasks.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Double Click:</strong> Opens the <strong>Edit Task</strong> dialog to modify the title, start and due dates, priority, and sub-tasks.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Right Click:</strong> Opens a <strong>Context Menu</strong> with options to Edit (GUI), Edit Text (Note), Delete the task, or Expand Subtasks (a read-only collapsible view of the sub-task tree).</li>
                     <li style={{ marginBottom: '12px' }}><strong>(+) Button:</strong> Opens the <strong>New Task</strong> dialog. You can also create new projects directly from there.</li>
                     <li style={{ marginBottom: '12px' }}><strong>(🚨) Urgent Toggle:</strong> Filters the view to show <strong>ONLY</strong> tasks that are Overdue or Approaching a deadline.</li>
                     <li style={{ marginBottom: '12px' }}><strong>Project Filter:</strong> Use the dropdown in the header to focus on a specific project or view "All Tasks".</li>
@@ -95,9 +108,9 @@ const InfoView: React.FC = () => {
 
             <section style={{ marginBottom: '30px' }}>
                 <h3 style={{ color: 'var(--text-color)', fontSize: '1.4rem' }}>🏗️ Advanced Sub-tasks</h3>
-                <p>Manage complex tasks with 6-level nested hierarchies directly from the Task Dialog or Kanban cards using a collapsible tree view. You can also open subtasks in a Fullscreen Overlay (⤢) for easier management of large lists.</p>
-                
-                <h4 style={{ marginTop: '15px', color: 'var(--text-color)', fontSize: '1.1rem' }}>Hierarchical Drag & Drop:</h4>
+                <p>Manage complex tasks with up to 6 levels of nested sub-tasks. Build and reorganize the hierarchy with drag &amp; drop in the <strong>New / Edit Task</strong> dialog, using a collapsible tree view. From a Kanban card, the context-menu <strong>Expand Subtasks</strong> action opens a Fullscreen Overlay (⤢), a <strong>read-only</strong> collapsible view for inspecting large trees.</p>
+
+                <h4 style={{ marginTop: '15px', color: 'var(--text-color)', fontSize: '1.1rem' }}>Hierarchical Drag &amp; Drop (in the Task dialog):</h4>
                 <p style={{ marginBottom: '10px', opacity: 0.9 }}>Use the drag handles (<span style={{ fontFamily: 'monospace', fontWeight: 'bold' }}>⋮⋮</span>) to easily grab and move items.</p>
                 <ul style={{ paddingLeft: '25px', marginTop: '10px' }}>
                     <li style={{ marginBottom: '8px' }}><strong>Reorder:</strong> Drag items <strong>above</strong> or <strong>below</strong> others to reorder them as siblings.</li>
@@ -112,21 +125,25 @@ const InfoView: React.FC = () => {
                 </ul>
 
                 <h4 style={{ marginTop: '15px', color: 'var(--text-color)', fontSize: '1.1rem' }}>Smart Checkboxes (Cascading Logic):</h4>
+                <p style={{ marginBottom: '10px', opacity: 0.9 }}>Toggling a checkbox on a card or in the overlay updates the whole hierarchy <strong>instantly</strong>, with no refresh delay:</p>
                 <ul style={{ paddingLeft: '25px', marginTop: '10px' }}>
                     <li style={{ marginBottom: '8px' }}><strong>Check Parent:</strong> Automatically checks <strong>all nested sub-tasks</strong> (convenience).</li>
                     <li style={{ marginBottom: '8px' }}><strong>Uncheck Child:</strong> Automatically unchecks <strong>all parent tasks</strong> up to the root (safety: a parent cannot be done if a child isn't).</li>
                     <li style={{ marginBottom: '8px' }}><strong>Independent Uncheck:</strong> Unchecking a parent does <strong>NOT</strong> uncheck children (preserves your progress on sub-items).</li>
+                    <li style={{ marginBottom: '8px' }}><strong>Re-nesting:</strong> When you change the hierarchy in the dialog, completion is preserved per item and the rules are re-applied, so a parent left complete above an incomplete child is automatically cleared.</li>
                 </ul>
             </section>
 
             <section style={{ marginBottom: '30px' }}>
-                <h3 style={{ color: 'var(--text-color)', fontSize: '1.4rem' }}>🚦 Sorting Logic</h3>
-                <p>Tasks in all views are consistently ordered by:</p>
-                <ol style={{ paddingLeft: '25px' }}>
-                    <li style={{ marginBottom: '12px' }}><strong>Due Date:</strong> Most urgent deadlines first.</li>
-                    <li style={{ marginBottom: '12px' }}><strong>Priority:</strong> High 🔴 &gt; Normal 🟠 &gt; Low 🔵.</li>
-                    <li style={{ marginBottom: '12px' }}><strong>Creation Date:</strong> Oldest tasks first (for same deadline/priority).</li>
-                </ol>
+                <h3 style={{ color: 'var(--text-color)', fontSize: '1.4rem' }}>🚦 Sorting</h3>
+                <p>Use the <strong>Sort</strong> dropdown in the header to order tasks consistently across the task views. Available criteria:</p>
+                <ul style={{ paddingLeft: '25px' }}>
+                    <li style={{ marginBottom: '12px' }}><strong>Due Date</strong> (default): Earliest deadline first; ties are broken by priority.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Start Date:</strong> Earliest start first (falling back to the creation date when no start is set).</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Priority:</strong> High 🔴 &gt; Medium 🟠 &gt; Low 🔵.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Created Time:</strong> Newest tasks first.</li>
+                </ul>
+                <p style={{ marginTop: '15px', opacity: 0.9 }}>Sorting, the urgency filter, and the project filter only apply where they have an effect: the sort and urgency controls are disabled in the <strong>Wiki</strong> and <strong>Guide</strong> tabs, and the project filter is disabled in the <strong>Guide</strong> tab. They re-enable automatically when you return to a compatible view.</p>
                 <p style={{ marginTop: '15px' }}><strong>Note on "Done" column:</strong> To keep the board clean, tasks completed more than <strong>30 days ago</strong> are automatically hidden from the "Done" column. The counter in the column header shows "Visible / Total" tasks.</p>
             </section>
 
@@ -153,7 +170,11 @@ const InfoView: React.FC = () => {
                 <p>The Wiki view transforms your project notes into a browsable documentation site.</p>
                 <ul style={{ paddingLeft: '25px', marginTop: '10px' }}>
                     <li style={{ marginBottom: '12px' }}><strong>Rich Content:</strong> Supports <strong>GFM Tables</strong>, <strong>Task Lists</strong>, and <strong>Code Snippets</strong> with adaptive syntax highlighting.</li>
-                    <li style={{ marginBottom: '12px' }}><strong>Navigation:</strong> Use the collapsible sidebar to navigate between folders and notes. The layout is responsive.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Internal Links:</strong> Click a link to another note to scroll straight to it within the Wiki, or open it in the editor when it lives outside the current project.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Resource Icons:</strong> Links to attachments are prefixed with a type icon (video 🎬, audio 🎵, PDF 📕, or a generic file 📎), and notes are marked too, so you can tell what each link points to.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Inline Media:</strong> Video and audio attachments open directly in an embedded player, without leaving the dashboard.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Live Checkboxes:</strong> Ticking a checkbox in a rendered note is saved back to the source note.</li>
+                    <li style={{ marginBottom: '12px' }}><strong>Navigation &amp; Layout:</strong> Use the collapsible sidebar to browse folders and notes; the reading area adapts fluidly to the available width and reclaims space when the sidebar is hidden.</li>
                     <li style={{ marginBottom: '12px' }}><strong>Theme Integration:</strong> Automatically adapts to your Joplin theme (Light/Dark), ensuring code blocks and headers always look perfect.</li>
                 </ul>
             </section>

--- a/src/gui/react/components/KanbanBoard.tsx
+++ b/src/gui/react/components/KanbanBoard.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { createPortal } from 'react-dom';
 import { Task, Project } from '../types';
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 import {formatDate} from "../utils";
@@ -225,25 +226,39 @@ const KanbanBoard: React.FC<KanbanBoardProps> = ({ tasks, onUpdateStatus, onTogg
 
         return (
             <React.Fragment>
-                {isExpanded && (
-                    <div 
-                        className="subtasks-expanded-backdrop" 
-                        onClick={(e) => { e.stopPropagation(); setExpandedTask(null); }}
-                    />
-                )}
-                <div className={`task-subtasks-wrapper ${isExpanded ? 'subtasks-expanded-overlay' : ''}`} style={!isExpanded ? { display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, overflow: 'hidden' } : {}}>
-                    {isExpanded && (
-                        <div className="subtasks-expanded-header">
-                            <h3>Subtasks for: {task.title}</h3>
-                            <button className="subtasks-close-btn" onClick={(e) => { e.stopPropagation(); setExpandedTask(null); }}>
-                                &times;
-                            </button>
-                        </div>
-                    )}
-                    <div className={`task-subtasks-container ${isExpanded ? 'expanded' : ''}`} style={{ marginTop: (!isExpanded) ? '8px' : '0', overflowY: 'auto', flex: 1, minHeight: 0, maxHeight: '100%' }}>
+                {/* Inline subtask list shown inside the card. */}
+                <div className="task-subtasks-wrapper" style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, overflow: 'hidden' }}>
+                    <div className="task-subtasks-container" style={{ marginTop: '8px', overflowY: 'auto', flex: 1, minHeight: 0, maxHeight: '100%' }}>
                         {tree.map(node => renderNode(node))}
                     </div>
                 </div>
+
+                {/*
+                  * The fullscreen overlay is rendered through a portal to document.body so it
+                  * escapes the Kanban drag-and-drop context and any transformed ancestor:
+                  * this stops clicks from reaching the cards behind it and prevents an
+                  * interaction inside the overlay from starting a card drag.
+                  */}
+                {isExpanded && createPortal(
+                    <React.Fragment>
+                        <div
+                            className="subtasks-expanded-backdrop"
+                            onClick={() => setExpandedTask(null)}
+                        />
+                        <div className="task-subtasks-wrapper subtasks-expanded-overlay">
+                            <div className="subtasks-expanded-header">
+                                <h3>Subtasks for: {task.title}</h3>
+                                <button className="subtasks-close-btn" onClick={() => setExpandedTask(null)}>
+                                    &times;
+                                </button>
+                            </div>
+                            <div className="task-subtasks-container expanded" style={{ marginTop: '0', overflowY: 'auto', flex: 1, minHeight: 0, maxHeight: '100%' }}>
+                                {tree.map(node => renderNode(node))}
+                            </div>
+                        </div>
+                    </React.Fragment>,
+                    document.body
+                )}
             </React.Fragment>
         );
     };

--- a/src/gui/react/components/TimelineView.tsx
+++ b/src/gui/react/components/TimelineView.tsx
@@ -22,6 +22,13 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tasks, sortOption, sortAppl
     const [containerWidth, setContainerWidth] = React.useState<number>(800);
     const wrapperRef = React.useRef<HTMLDivElement>(null);
     const bodyRef = React.useRef<HTMLDivElement>(null);
+    // Tracks whether the initial centering on today has run for this mount, so the timeline
+    // opens centered on the current day the first time it gains a real width (e.g. when the
+    // tab is first shown) without overriding the user's scroll afterwards.
+    const hasCenteredOnToday = React.useRef(false);
+    // Set when a bar drag ends so the synthetic click that follows does not also scroll the
+    // row to its task; reset by the next row interaction.
+    const suppressRowClickRef = React.useRef(false);
 
     const [draggingDep, setDraggingDep] = React.useState<{id: string, type: 'start'|'end', projectId: string} | null>(null);
     const [mousePos, setMousePos] = React.useState<{x: number, y: number} | null>(null);
@@ -61,7 +68,7 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tasks, sortOption, sortAppl
     const rowOrderRef = React.useRef<string[]>([]);
     rowOrderRef.current = timelineTasks.map(t => t.id);
 
-    // Re-applying the global sort — selecting a new option or re-using the sort control —
+    // Re-applying the global sort (selecting a new option or re-using the sort control)
     // resumes automatic ordering.
     React.useEffect(() => { setFrozenOrder(null); }, [sortOption, sortApplyToken]);
 
@@ -180,6 +187,7 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tasks, sortOption, sortAppl
         };
         const onUp = () => {
             if (draggingTask) {
+                suppressRowClickRef.current = true;
                 const draggedId = draggingTask.id;
                 const tempDates = tempTaskDates[draggedId];
                 if (tempDates) {
@@ -192,7 +200,7 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tasks, sortOption, sortAppl
                                  startDate: tempDates.start,
                                  dueDate: tempDates.end,
                                  subTasks: updatedTask.subTasks,
-                                 urgency: updatedTask.tags.find(t => ['high','medium','normal','low'].includes(t.toLowerCase())) || 'normal'
+                                 urgency: updatedTask.tags.find(t => ['high','medium','low'].includes(t.toLowerCase())) || 'medium'
                              }
                          });
                     }
@@ -404,9 +412,34 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tasks, sortOption, sortAppl
     };
 
     React.useEffect(() => {
-        handleScroll();
-        window.addEventListener('resize', handleScroll);
-        return () => window.removeEventListener('resize', handleScroll);
+        /**
+         * Centers the timeline on today the first time it has a real width, so a freshly
+         * opened timeline starts on the current day; later size changes leave the user's
+         * scroll untouched.
+         */
+        const centerOnTodayOnce = () => {
+            if (hasCenteredOnToday.current) return;
+            if (!wrapperRef.current || wrapperRef.current.clientWidth === 0) return;
+            handleJumpTo('today', 'auto');
+            hasCenteredOnToday.current = true;
+        };
+
+        const measure = () => { handleScroll(); centerOnTodayOnce(); };
+
+        measure();
+        window.addEventListener('resize', measure);
+        // A ResizeObserver re-measures when the wrapper gains a real size again, which happens
+        // when the tab becomes visible after being hidden or when the panel is resized; the
+        // mount-time measurement is 0 while the view is hidden.
+        let observer: ResizeObserver | null = null;
+        if (wrapperRef.current && typeof ResizeObserver !== 'undefined') {
+            observer = new ResizeObserver(() => measure());
+            observer.observe(wrapperRef.current);
+        }
+        return () => {
+            window.removeEventListener('resize', measure);
+            if (observer) observer.disconnect();
+        };
     }, [viewDuration, startRange, zoomLevel]);
 
     /**
@@ -604,7 +637,7 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tasks, sortOption, sortAppl
      * centered in the viewport.
      * @param target The point to scroll to.
      */
-    const handleJumpTo = (target: 'start' | 'today' | 'end') => {
+    const handleJumpTo = (target: 'start' | 'today' | 'end', behavior: ScrollBehavior = 'smooth') => {
         if (!wrapperRef.current) return;
         const wrapper = wrapperRef.current;
         const viewportWidth = wrapper.clientWidth;
@@ -624,6 +657,30 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tasks, sortOption, sortAppl
 
         const targetScrollLeft = (targetPercent * scrollWidth) - (viewportWidth / 2);
         
+        wrapper.scrollTo({
+            left: Math.max(0, Math.min(targetScrollLeft, scrollWidth - viewportWidth)),
+            behavior: behavior
+        });
+    };
+
+    /**
+     * Smoothly scrolls the timeline so the given task's bar is centered in the viewport,
+     * which brings into view tasks whose bars sit off-screen, such as overdue tasks that
+     * fall before the current day.
+     * @param task The task to bring into view.
+     */
+    const scrollToTask = (task: Task) => {
+        if (!wrapperRef.current) return;
+        const wrapper = wrapperRef.current;
+        const viewportWidth = wrapper.clientWidth;
+        const scrollWidth = wrapper.scrollWidth;
+
+        const start = tempTaskDates[task.id] ? tempTaskDates[task.id].start : (task.startDate || task.createdTime);
+        const due = tempTaskDates[task.id] ? tempTaskDates[task.id].end : (task.dueDate || start);
+        const midpoint = start + (due - start) / 2;
+        const targetPercent = (midpoint - startRange) / viewDuration;
+        const targetScrollLeft = (targetPercent * scrollWidth) - (viewportWidth / 2);
+
         wrapper.scrollTo({
             left: Math.max(0, Math.min(targetScrollLeft, scrollWidth - viewportWidth)),
             behavior: 'smooth'
@@ -872,8 +929,17 @@ const TimelineView: React.FC<TimelineViewProps> = ({ tasks, sortOption, sortAppl
                         const isMilestone = effectiveDue - effectiveStart <= 0;
 
                         return (
-                            <div key={task.id} className={`timeline-row ${isOverdue ? 'overdue' : ''} ${isApproaching ? 'approaching' : ''} ${isDroppableTarget ? 'droppable' : ''}`} 
-                                 style={{ height: '60px', position: 'relative', borderBottom: '1px solid var(--joplin-divider-color)', margin: '0 10px', cursor: draggingDep ? 'copy' : 'pointer' }} 
+                            <div key={task.id} className={`timeline-row ${isOverdue ? 'overdue' : ''} ${isApproaching ? 'approaching' : ''} ${isDroppableTarget ? 'droppable' : ''}`}
+                                 style={{ height: '60px', position: 'relative', borderBottom: '1px solid var(--joplin-divider-color)', margin: '0 10px', cursor: draggingDep ? 'copy' : 'pointer' }}
+                                 onMouseDown={() => { suppressRowClickRef.current = false; }}
+                                 onClick={(e) => {
+                                     // Skip the synthetic click that follows a bar drag, the second click of a
+                                     // double-click (which edits), and clicks on dependency handles.
+                                     if (suppressRowClickRef.current) { suppressRowClickRef.current = false; return; }
+                                     if (e.detail > 1) return;
+                                     if ((e.target as HTMLElement).closest('.dep-handle')) return;
+                                     scrollToTask(task);
+                                 }}
                                  onDoubleClick={(e) => { e.stopPropagation(); onEditTask(task); }}
                                  onContextMenu={(e) => handleContextMenu(e, task)}
                                  title={`${task.projectName}\n${task.title}${task.startDate && task.startDate > 0 ? `\nStart: ${formatDate(task.startDate)}` : ''}${task.dueDate! > 0 ? `\n${isOverdue ? '(Overdue) ' : (isApproaching ? '(Approaching) ' : '')}Due: ${formatDate(task.dueDate!)}` : ''}`}>

--- a/src/gui/react/components/WikiView.tsx
+++ b/src/gui/react/components/WikiView.tsx
@@ -30,11 +30,54 @@ const getConfiguredMdParser = (): MarkdownIt => {
 
 const mdParser = getConfiguredMdParser();
 
+/**
+ * Maps a rendered wiki link to its icon (a Font Awesome class with an emoji fallback)
+ * based on the target: internal note links (distinguishing notes present in the current
+ * wiki from external ones) and local resource links by MIME type. Returns null for links
+ * that should carry no icon; inline images are rendered as <img>, never as links.
+ * @param anchor The rendered anchor element.
+ */
+const wikiLinkIcon = (anchor: HTMLAnchorElement): { fa: string, emoji: string } | null => {
+    const raw = anchor.getAttribute('href') || '';
+    const noteLink = raw.match(/^:\/([0-9a-f]{32})$/i);
+    if (noteLink) {
+        return document.getElementById(`wiki-section-${noteLink[1]}`)
+            ? { fa: 'fas fa-file-alt', emoji: '📄' }
+            : { fa: 'fas fa-external-link-alt', emoji: '🔗' };
+    }
+    if (raw.startsWith('file://')) {
+        let mime = '';
+        try { mime = new URLSearchParams(new URL(raw).hash.substring(1)).get('mime') || ''; } catch (e) { /* malformed URI */ }
+        if (mime.startsWith('video/')) return { fa: 'fas fa-film', emoji: '🎬' };
+        if (mime.startsWith('audio/')) return { fa: 'fas fa-music', emoji: '🎵' };
+        if (mime === 'application/pdf') return { fa: 'fas fa-file-pdf', emoji: '📕' };
+        return { fa: 'fas fa-paperclip', emoji: '📎' };
+    }
+    return null;
+};
+
+/**
+ * Detects whether a Font Awesome icon font is loaded in the panel, so link icons can fall
+ * back to emoji when it is not available.
+ */
+const isFontAwesomeAvailable = (): boolean => {
+    try {
+        const fonts: any = (document as any).fonts;
+        if (!fonts || typeof fonts.check !== 'function') return false;
+        return fonts.check('16px "Font Awesome 6 Free"')
+            || fonts.check('900 16px "Font Awesome 6 Free"')
+            || fonts.check('16px "Font Awesome 5 Free"')
+            || fonts.check('16px FontAwesome');
+    } catch (e) {
+        return false;
+    }
+};
+
 interface WikiViewProps {
     projectId: string;
     onOpenNote: (noteId: string) => void;
-    onToggleSubTask?: (taskId: string, subTaskIndex: number, checked: boolean) => void;
     lastUpdated: number;
+    isActive: boolean;
 }
 
 /**
@@ -180,7 +223,7 @@ const TocLevel: React.FC<{
  * contents, sanitized and syntax-highlighted Markdown rendering, task-list toggling,
  * and an inline media player for local video and audio resources.
  */
-const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, onToggleSubTask, lastUpdated }) => {
+const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, lastUpdated, isActive }) => {
     const [wikiData, setWikiData] = useState<WikiNode[]>([]);
     const [loading, setLoading] = useState(true);
     const [isTocOpen, setIsTocOpen] = useState(() => {
@@ -194,6 +237,10 @@ const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, onToggleSubT
     const wikiTree = useMemo(() => buildTree(wikiData), [wikiData]);
     
     useEffect(() => {
+        // The wiki query is the heaviest backend call, so it is fetched only while the view
+        // is the active tab; kept mounted but inactive, it retains its last render and scroll
+        // without polling in the background, and refreshes when reactivated.
+        if (!isActive) return;
         let mounted = true;
         /**
          * Fetches the wiki structure for the current project, ignoring the response if
@@ -210,7 +257,7 @@ const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, onToggleSubT
         };
         fetchWiki();
         return () => { mounted = false; };
-    }, [projectId, lastUpdated]);
+    }, [projectId, lastUpdated, isActive]);
 
     /**
      * Reorders a note or folder within its sibling group after a drag-and-drop, updates
@@ -314,6 +361,7 @@ const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, onToggleSubT
 
     useEffect(() => {
         if (!loading && wikiData) {
+            const faAvailable = isFontAwesomeAvailable();
             contentRef.current?.querySelectorAll('.markdown-content').forEach(el => {
                 const markdown = el.getAttribute('data-markdown');
                 if (markdown) {
@@ -322,6 +370,19 @@ const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, onToggleSubT
                         ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|file):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i
                     });
                     el.innerHTML = cleanHtml;
+
+                    // Prefix note and resource links with a type icon (images render as <img>,
+                    // so they are unaffected).
+                    el.querySelectorAll('a').forEach((a) => {
+                        const icon = wikiLinkIcon(a as HTMLAnchorElement);
+                        if (!icon) return;
+                        const marker = document.createElement(faAvailable ? 'i' : 'span');
+                        if (faAvailable) marker.className = icon.fa;
+                        else marker.textContent = icon.emoji;
+                        marker.style.marginRight = '5px';
+                        marker.style.opacity = '0.75';
+                        a.prepend(marker);
+                    });
                 }
             });
             contentRef.current?.querySelectorAll('pre code').forEach((block) => hljs.highlightElement(block as HTMLElement));
@@ -329,14 +390,31 @@ const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, onToggleSubT
     }, [loading, wikiData]);
 
     /**
-     * Handles clicks within the rendered wiki content, opening local video and audio
-     * resources in the inline media player and forwarding task-list checkbox toggles.
+     * Handles clicks within the rendered wiki content: navigating internal note links,
+     * opening local video and audio resources in the inline media player, and persisting
+     * note checkbox toggles back to the source note.
      * @param e The click event.
      */
     const handleContentClick = (e: React.MouseEvent) => {
         const target = e.target as HTMLElement;
-        if (target.tagName === 'A') {
-            const href = (target as HTMLAnchorElement).href;
+        const anchor = target.closest('a');
+        if (anchor) {
+            // Joplin internal note links (`:/<32-hex>`): scroll to the target note when it is
+            // part of the current wiki, otherwise open it in the editor.
+            const rawHref = anchor.getAttribute('href') || '';
+            const noteLink = rawHref.match(/^:\/([0-9a-f]{32})$/i);
+            if (noteLink) {
+                e.preventDefault();
+                const noteId = noteLink[1];
+                if (document.getElementById(`wiki-section-${noteId}`)) {
+                    scrollToSection(noteId);
+                } else {
+                    onOpenNote(noteId);
+                }
+                return;
+            }
+
+            const href = anchor.href;
             if (href.startsWith('file://')) {
                 let type: 'video' | 'audio' | null = null;
                 let mime = '';
@@ -349,7 +427,7 @@ const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, onToggleSubT
                 else if (mime.startsWith('audio/')) type = 'audio';
                 if (type) {
                     e.preventDefault();
-                    setActiveMedia({ url: href.split('#')[0], type: type, name: target.innerText || 'Media' });
+                    setActiveMedia({ url: href.split('#')[0], type: type, name: anchor.innerText || 'Media' });
                 }
             }
         }
@@ -358,16 +436,17 @@ const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, onToggleSubT
             const checkbox = target as HTMLInputElement;
             const noteContainer = target.closest('[id^="wiki-section-"]');
             const markdownContent = target.closest('.markdown-content');
-            
+
             if (noteContainer && markdownContent) {
                 const noteId = noteContainer.id.replace('wiki-section-', '');
                 const checkboxes = Array.from(markdownContent.querySelectorAll('input[type="checkbox"]'));
-                const subTaskIndex = checkboxes.indexOf(checkbox);
-                
-                if (subTaskIndex !== -1 && onToggleSubTask) {
-                    // The toggle is forwarded to the backend, which persists the change
-                    // and pushes the updated state back through Joplin's note watcher.
-                    onToggleSubTask(noteId, subTaskIndex, checkbox.checked);
+                const checkboxIndex = checkboxes.indexOf(checkbox);
+
+                if (checkboxIndex !== -1) {
+                    // Wiki note checkboxes are plain markdown checkboxes, not task subtasks, so
+                    // the toggle is sent straight to the backend to flip that checkbox by index
+                    // in the source note; the note watcher then refreshes the wiki.
+                    window.webviewApi.postMessage({ name: 'toggleWikiCheckbox', payload: { noteId, index: checkboxIndex, checked: checkbox.checked } });
                 }
             }
         }
@@ -386,6 +465,30 @@ const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, onToggleSubT
                 .markdown-body a {
                     color: var(--joplin-color) !important;
                     text-decoration: underline;
+                }
+
+                /* Responsive reader: content flows to the available width with a readable
+                   maximum measure, while intrinsically wide elements scroll or scale inside
+                   their own box instead of forcing the whole pane to scroll horizontally. */
+                .wiki-reader-content .markdown-content {
+                    overflow-wrap: break-word;
+                    word-break: break-word;
+                }
+                .wiki-reader-content .markdown-body img {
+                    max-width: 100%;
+                    height: auto;
+                }
+                .wiki-reader-content .markdown-body pre {
+                    max-width: 100%;
+                    overflow-x: auto;
+                }
+                .wiki-reader-content .markdown-body table {
+                    display: block;
+                    max-width: 100%;
+                    overflow-x: auto;
+                }
+                .wiki-reader-content .markdown-body a {
+                    overflow-wrap: anywhere;
                 }
 
                 /* Adaptive Drop Hint Variables */
@@ -425,19 +528,19 @@ const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, onToggleSubT
 
                 <div className="sidebar-toggle" onClick={() => setIsTocOpen(!isTocOpen)} title={isTocOpen ? "Collapse Sidebar" : "Expand Sidebar"}><i className={`fas fa-chevron-${isTocOpen ? 'left' : 'right'}`} style={{ fontSize: '0.9rem' }}></i></div>
 
-                <div ref={contentRef} onClick={handleContentClick} className="wiki-reader-content" style={{ flex: 1, overflowY: 'auto', overflowX: 'auto', scrollBehavior: 'smooth', boxSizing: 'border-box' }}>
-                    <div style={{ padding: '25px', width: 'fit-content', display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+                <div ref={contentRef} onClick={handleContentClick} className="wiki-reader-content" style={{ flex: 1, minWidth: 0, overflowY: 'auto', overflowX: 'hidden', scrollBehavior: 'smooth', boxSizing: 'border-box' }}>
+                    <div style={{ padding: '25px', width: '100%', maxWidth: '1000px', margin: '0 auto', boxSizing: 'border-box' }}>
                         {wikiData.map(node => (
                             <div id={`wiki-section-${node.id}`} key={node.id} style={{ marginBottom: '40px', width: '100%' }}>
                                 {node.type === 'folder' ? (
-                                    <h2 className="wiki-folder-header" style={{ fontSize: `${Math.max(1.1, 1.5 - (node.level * 0.1))}rem`, margin: '0 0 20px 0', whiteSpace: 'nowrap' }}>{node.title}</h2>
+                                    <h2 className="wiki-folder-header" style={{ fontSize: `${Math.max(1.1, 1.5 - (node.level * 0.1))}rem`, margin: '0 0 20px 0', overflowWrap: 'break-word' }}>{node.title}</h2>
                                 ) : (
                                     <div className="wiki-page">
                                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '15px' }}>
-                                            <h3 className="wiki-page-header" style={{ margin: 0, whiteSpace: 'nowrap' }}><span style={{ fontSize: '1rem' }}>📄</span> {node.title}</h3>
-                                            <button onClick={() => onOpenNote(node.id)} style={{ background: 'none', border: '1px solid var(--border-color)', borderRadius: '4px', padding: '4px 8px', cursor: 'pointer', fontSize: '0.8rem', color: 'var(--joplin-color)', opacity: 0.7, marginLeft: '20px' }} title="Open in Editor">Edit ✏️</button>
+                                            <h3 className="wiki-page-header" style={{ margin: 0, minWidth: 0, overflowWrap: 'break-word' }}><span style={{ fontSize: '1rem' }}>📄</span> {node.title}</h3>
+                                            <button onClick={() => onOpenNote(node.id)} style={{ background: 'none', border: '1px solid var(--border-color)', borderRadius: '4px', padding: '4px 8px', cursor: 'pointer', fontSize: '0.8rem', color: 'var(--joplin-color)', opacity: 0.7, marginLeft: '20px', flexShrink: 0 }} title="Open in Editor">Edit ✏️</button>
                                         </div>
-                                        <div className="markdown-body" style={{ background: 'var(--joplin-background-color)', border: '1px solid var(--border-color)', borderRadius: '6px', padding: '25px', lineHeight: '1.6', fontSize: '0.95rem' }}>
+                                        <div className="markdown-body" style={{ background: 'var(--joplin-background-color)', border: '1px solid var(--border-color)', borderRadius: '6px', padding: '25px', lineHeight: '1.6', fontSize: '0.95rem', width: '100%', boxSizing: 'border-box' }}>
                                             <div className="markdown-content" data-markdown={node.body || "_No content._"}></div>
                                         </div>
                                     </div>

--- a/src/gui/react/types.ts
+++ b/src/gui/react/types.ts
@@ -4,6 +4,8 @@
 export interface SubTask {
     title: string;
     completed: boolean;
+    level: number;
+    originalIndex: number;
 }
 
 /**

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 1,
 	"id": "com.scrayil.joplin-plugin-projects",
 	"app_min_version": "3.4.12",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"name": "Projects",
 	"description": "Easily manage and schedule projects, integrating tasks directly with your knowledge base.",
 	"author": "Mattia Bennati (Scrayil)",

--- a/src/services/NoteParser.ts
+++ b/src/services/NoteParser.ts
@@ -135,6 +135,69 @@ export class NoteParser {
     }
 
     /**
+     * Sets the state of a single GFM task-list checkbox identified by its zero-based index
+     * in document order, supporting the "-", "*" and "+" list markers and leaving every
+     * other line untouched. No completion cascade is applied, so it suits plain note
+     * checklists rather than task subtasks.
+     * @param body The note markdown.
+     * @param index The zero-based index of the checkbox to set.
+     * @param checked The desired checkbox state.
+     * @returns The updated markdown, or the original body if the index is out of range.
+     */
+    public toggleCheckboxAt(body: string, index: number, checked: boolean): string {
+        if (!body) return body;
+        const lines = body.split('\n');
+        const checkboxRegex = /^(\s*[-*+]\s+\[)([ xX])(\].*)$/;
+        let count = -1;
+        for (let i = 0; i < lines.length; i++) {
+            const match = lines[i].match(checkboxRegex);
+            if (match) {
+                count++;
+                if (count === index) {
+                    lines[i] = `${match[1]}${checked ? 'x' : ' '}${match[3]}`;
+                    break;
+                }
+            }
+        }
+        return lines.join('\n');
+    }
+
+    /**
+     * Enforces the completion invariant that a subtask cannot stay completed while any of
+     * its descendants is incomplete. Every completed subtask that has an incomplete
+     * descendant is cleared, so restructuring the hierarchy never leaves a parent marked
+     * done over unfinished children. Leaf states, titles, and indentation are preserved.
+     * @param body The note markdown.
+     * @returns The markdown with parent completion states normalized.
+     */
+    public normalizeSubTaskHierarchy(body: string): string {
+        if (!body) return body;
+        const tasks = this.parseSubTasks(body);
+        if (tasks.length === 0) return body;
+
+        for (let i = 0; i < tasks.length; i++) {
+            if (!tasks[i].completed) continue;
+            for (let j = i + 1; j < tasks.length && tasks[j].level > tasks[i].level; j++) {
+                if (!tasks[j].completed) {
+                    tasks[i].completed = false;
+                    break;
+                }
+            }
+        }
+
+        const lines = body.split('\n');
+        const newLines = [...lines];
+        for (const task of tasks) {
+            const originalLine = lines[task.originalIndex];
+            const indentMatch = originalLine.match(/^(\s*)-/);
+            const prefix = indentMatch ? indentMatch[1] : '  '.repeat(task.level);
+            const mark = task.completed ? 'x' : ' ';
+            newLines[task.originalIndex] = `${prefix}- [${mark}] ${task.title}`;
+        }
+        return newLines.join('\n');
+    }
+
+    /**
      * Replaces existing subtasks in the note body with a new list.
      * Handles complex replacement while preserving indentation.
      */
@@ -168,17 +231,20 @@ export class NoteParser {
             }
         });
 
+        let rebuilt: string;
         if (firstTaskLine === -1) {
-            if (currentBody.trim().length > 0) {
-                return currentBody + '\n\n' + formattedNewTasks.join('\n');
-            } else {
-                return formattedNewTasks.join('\n');
-            }
+            rebuilt = currentBody.trim().length > 0
+                ? currentBody + '\n\n' + formattedNewTasks.join('\n')
+                : formattedNewTasks.join('\n');
         } else {
             const before = lines.slice(0, firstTaskLine);
             const after = lines.slice(lastTaskLine + 1);
-            return [...before, ...formattedNewTasks, ...after].join('\n');
+            rebuilt = [...before, ...formattedNewTasks, ...after].join('\n');
         }
+
+        // Re-parenting in the editor can leave a completed parent above an incomplete child;
+        // the hierarchy is normalized so such parents are cleared.
+        return this.normalizeSubTaskHierarchy(rebuilt);
     }
 
     /**

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -5,7 +5,7 @@ import { NoteParser } from './NoteParser';
 import * as path from 'path';
 import * as fs from 'fs';
 import { getOrInitProjectRootId } from '../utils/projects';
-import { fetchAllItems, getNote, createNotebook, getFolder, getResourcePath, getResource } from '../utils/database';
+import { fetchAllItems, getNote, createNotebook, getFolder, getResourcePath } from '../utils/database';
 import { PersistenceService } from './PersistenceService';
 import { SyncService } from './SyncService';
 
@@ -489,11 +489,26 @@ export class ProjectService {
                         const uniqueIds = Array.from(new Set(matches.map(m => m.id)));
                         const resourceMap = new Map<string, { path: string, mime: string }>();
 
+                        // A `:/` link may point to a resource or to another note. The note's
+                        // attached resources are listed first so that note links are never sent
+                        // to the resource API, which would otherwise log a "No such resource"
+                        // error for every internal note link in the wiki.
+                        const noteResources = await fetchAllItems(['notes', item.id, 'resources'], { fields: ['id', 'mime'] });
+                        const mimeByResourceId = new Map<string, string>(
+                            noteResources.map((res: any) => [res.id, res.mime || ''])
+                        );
+
                         await Promise.all(uniqueIds.map(async (id) => {
-                            const path = await getResourcePath(id);
-                            const meta = await getResource(id, ['mime']);
-                            if (path) {
-                                resourceMap.set(id, { path, mime: meta?.mime || '' });
+                            // IDs absent from the note's resource set are internal note links and
+                            // are left untouched for the frontend to resolve client-side.
+                            if (!mimeByResourceId.has(id)) return;
+                            try {
+                                const path = await getResourcePath(id);
+                                if (path) {
+                                    resourceMap.set(id, { path, mime: mimeByResourceId.get(id) || '' });
+                                }
+                            } catch (e) {
+                                // Resource path resolution failed; the link is kept as-is.
                             }
                         }));
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -38,7 +38,6 @@ export const Config = {
             HIGH: 'high',
             MEDIUM: 'medium',
             LOW: 'low',
-            NORMAL: 'normal',
             IN_PROGRESS: 'in progress',
             DOING: 'doing'
         }


### PR DESCRIPTION
## Summary
This branch bundles the v1.5.0 work: the original minor issues (#41, #43, #44)
plus enhancements and fixes across the Wiki, Timeline, dashboard navigation,
and subtask handling.

## Wiki
- Internal note links scroll to the target note within the wiki, or open it in the editor when it lives elsewhere.
- Resource and note links are prefixed with type icons (video, audio, PDF, generic file), using Font Awesome with an emoji fallback.
- Checkbox toggles in a rendered note are saved back to the source note.
- The reading area flows to the available width, with wide elements scrolling inside their own box.
- Resource lookups are limited to a note's actual attachments, which stops the recurring "No such resource" console errors.

## Timeline
- Opens centered on today and re-measures when it becomes visible or the panel is resized.
- Clicking a task row scrolls its bar into view, which helps reach overdue tasks whose bars sit before today.

## Dashboard
- Switching tabs preserves each view's scroll position and state; views reset only when the dashboard is reopened from a hidden state.
- The sort, urgency, and project controls are disabled in views where they have no effect.
- The sort labels were decluttered.

## Tasks and subtasks
- The task title is editable in the GUI Edit dialog.
- Urgency levels are centralized (High/Medium/Low), removing the leftover "normal" level.
- Subtask completion is preserved through GUI edits and dependency-driven rescheduling, which previously reset checkboxes and flattened nesting.
- Re-nesting in the dialog normalizes the hierarchy, so a completed parent above an incomplete child is cleared.
- The nested completion cascade is reflected instantly across all views, and the Edit dialog marks completed subtasks.
- Sorting is deterministic, so toggling a subtask no longer reshuffles cards.
- The Kanban "Expand Subtasks" overlay no longer passes clicks through or hijacks card drag.

## Docs
- The in-app Guide and the README were updated to match the current features.

## Issues
Closes #41
Closes #43
Closes #44

## Testing
- Type check and bundle build pass on Node 24.16.0.