### PR TITLE
Perf/dashboard api call volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+[v1.5.1] - 09/08/26
+### ⚡ Performance
+- Dashboard refreshes now fetch tags once per tag rather than once per note, cutting API calls per refresh by roughly 10 times on a typical collection.
+- The wiki fetches the resource index once per load instead of once per note containing attachments.
+- Selecting a different note no longer invalidates the dashboard cache. The existing content signature already covers every change that matters.
+
+### ✨ Features & Enhancements
+- New advanced setting: the dashboard refresh interval, defaulting to the previous 3 seconds.
+- The dashboard shows an indicator when consecutive refreshes have failed, so a stalled panel is no longer silently stale.
+
+### 🐛 Bug Fixes
+- A failed refresh no longer replaces the dashboard with an empty state. The previous content is kept.
+- The wiki view no longer breaks when a load fails.
+- Resource links copied from another note are now resolved instead of being eft broken.
+
 [v1.5.0] - 17/06/26
 ### ✨ Features & Enhancements
 - Wiki: internal note links now scroll to the target note within the wiki, or open it in the editor when it lives elsewhere.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-projects",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "scripts": {
     "dist": "webpack --env joplin-plugin-config=buildMain && webpack --env joplin-plugin-config=buildExtraScripts && webpack --env joplin-plugin-config=createArchive",
     "prepare": "npm run dist",

--- a/src/gui/TaskDashboard.ts
+++ b/src/gui/TaskDashboard.ts
@@ -146,7 +146,6 @@ export class TaskDashboard {
         await joplin.workspace.onNoteSelectionChange(async () => {
             const isVisible = await joplin.views.panels.visible(this.panelHandle);
             if (isVisible) {
-                this.projectService.invalidateCache();
                 await joplin.views.panels.postMessage(this.panelHandle, { name: 'dataChanged' });
             }
         });

--- a/src/gui/TaskDashboard.ts
+++ b/src/gui/TaskDashboard.ts
@@ -119,6 +119,7 @@ export class TaskDashboard {
                     return;
                 }
             } catch (error) {
+                // Prints the error in the plugin's own console
                 console.error(`TaskDashboard: Error handling message ${message.name}:`, error);
             }
         });

--- a/src/gui/react/App.tsx
+++ b/src/gui/react/App.tsx
@@ -114,46 +114,49 @@ const App: React.FC = () => {
         }
     }, []);
 
+    /**
+     * Detects the active Joplin theme from the editor text color and applies the
+     * matching color scheme and theme classes to the document.
+     */
+    const updateTheme = React.useCallback(() => {
+        const textColor = getComputedStyle(document.body).getPropertyValue('--joplin-color').trim();
+        let isDarkTheme = false;
+
+        let r=0, g=0, b=0;
+        if (textColor.startsWith('#')) {
+            const hex = textColor.substring(1);
+            r = parseInt(hex.substring(0, 2), 16);
+            g = parseInt(hex.substring(2, 4), 16);
+            b = parseInt(hex.substring(4, 6), 16);
+        } else if (textColor.startsWith('rgb')) {
+            const parts = textColor.match(/\d+/g);
+            if (parts && parts.length >= 3) {
+                r = parseInt(parts[0]);
+                g = parseInt(parts[1]);
+                b = parseInt(parts[2]);
+            }
+        }
+
+        const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+        // Bright editor text indicates a dark theme.
+        if (brightness > 128) isDarkTheme = true;
+
+        document.documentElement.style.colorScheme = isDarkTheme ? 'dark' : 'light';
+        document.documentElement.style.setProperty('accent-color', 'var(--joplin-selected-color)');
+
+        if (isDarkTheme) {
+            document.body.classList.add('theme-dark');
+            document.body.classList.remove('theme-light');
+        } else {
+            document.body.classList.add('theme-light');
+            document.body.classList.remove('theme-dark');
+        }
+    }, []);
+
+    /**
+     * Detects note changes made outside the plugin, and uses fetched data to update the dashboard appearance and content.
+     */
     useEffect(() => {
-        /**
-         * Detects the active Joplin theme from the editor text color and applies the
-         * matching color scheme and theme classes to the document.
-         */
-        const updateTheme = () => {
-            const textColor = getComputedStyle(document.body).getPropertyValue('--joplin-color').trim();
-            let isDarkTheme = false;
-            
-            let r=0, g=0, b=0;
-            if (textColor.startsWith('#')) {
-                const hex = textColor.substring(1);
-                r = parseInt(hex.substring(0, 2), 16);
-                g = parseInt(hex.substring(2, 4), 16);
-                b = parseInt(hex.substring(4, 6), 16);
-            } else if (textColor.startsWith('rgb')) {
-                const parts = textColor.match(/\d+/g);
-                if (parts && parts.length >= 3) {
-                    r = parseInt(parts[0]);
-                    g = parseInt(parts[1]);
-                    b = parseInt(parts[2]);
-                }
-            }
-            
-            const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-            // Bright editor text indicates a dark theme.
-            if (brightness > 128) isDarkTheme = true;
-
-            document.documentElement.style.colorScheme = isDarkTheme ? 'dark' : 'light';
-            document.documentElement.style.setProperty('accent-color', 'var(--joplin-selected-color)');
-            
-            if (isDarkTheme) {
-                document.body.classList.add('theme-dark');
-                document.body.classList.remove('theme-light');
-            } else {
-                document.body.classList.add('theme-light');
-                document.body.classList.remove('theme-dark');
-            }
-        };
-
         updateTheme();
         fetchData();
 
@@ -168,13 +171,19 @@ const App: React.FC = () => {
                 }
             });
         }
+    }, [fetchData, updateTheme]);
 
-        const interval = setInterval(() => { 
-            fetchData(); 
+    /**
+     * Starts an interval timer that periodically updates the plugin's dashboard keeping it aligned with the actual notes.
+     */
+    const pollMs = (data as any)?.config?.pollingInterval ?? 3000;
+    useEffect(() => {
+        const interval = setInterval(() => {
+            fetchData();
             updateTheme();
-        }, 3000);
+        }, pollMs);
         return () => clearInterval(interval);
-    }, [fetchData]);
+    }, [fetchData, updateTheme, pollMs]);
 
     /**
      * Validates the selected project filter against the available projects and falls

--- a/src/gui/react/App.tsx
+++ b/src/gui/react/App.tsx
@@ -70,6 +70,10 @@ const App: React.FC = () => {
     const isFetching = React.useRef(false);
     const isDialogOpen = React.useRef(false);
 
+    // Stale dashboard indicators
+    const [staleSince, setStaleSince] = useState<number | null>(null);
+    const failures = React.useRef(0);
+
     // Optimistic overlay: per-task patches applied on top of server data so every view
     // reflects an action instantly. They are kept for a short window so the background
     // poll cannot revert a fresh action, then expire once the backend has caught up.
@@ -85,6 +89,12 @@ const App: React.FC = () => {
         isFetching.current = true;
         try {
             const response = await window.webviewApi.postMessage({ name: 'getData' });
+            // Keeps the previous data in case of errors. E.G.: undefined responses
+            // If no data is being retrieved, updates the stale indicator
+            if (!response) {
+                if (++failures.current >= 3) setStaleSince(s => s ?? Date.now());
+                return;
+            }
             // Skip the state update (and the re-render/re-sort it triggers) when the
             // polled data is unchanged, keeping the poll non-destructive.
             const serialized = JSON.stringify(response);
@@ -92,6 +102,9 @@ const App: React.FC = () => {
                 lastDataStr.current = serialized;
                 setData(response);
             }
+
+            failures.current = 0;
+            setStaleSince(null);
             setLastUpdated(Date.now());
             // Expire optimistic patches old enough for the backend to have caught up.
             setPendingPatches(prev => {
@@ -108,6 +121,7 @@ const App: React.FC = () => {
             });
         } catch (error) {
             console.error('Error fetching data:', error);
+            if (++failures.current >= 3) setStaleSince(s => s ?? Date.now());
         } finally {
             setLoading(false);
             isFetching.current = false;
@@ -571,6 +585,31 @@ const App: React.FC = () => {
                     </div>
                 </div>
             </div>
+            {staleSince && (
+                <div
+                    title={`Dashboard is not refreshing.\nLast successful update: ${new Date(lastUpdated).toLocaleTimeString()}`}
+                    style={{
+                        position: 'fixed',
+                        bottom: '12px',
+                        right: '12px',
+                        zIndex: 9999,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.35rem',
+                        padding: '0.3rem 0.6rem',
+                        borderRadius: '999px',
+                        fontSize: '0.75rem',
+                        whiteSpace: 'nowrap',
+                        cursor: 'default',
+                        color: 'var(--joplin-color-error, #d9534f)',
+                        backgroundColor: 'var(--joplin-background-color3, rgba(0,0,0,0.6))',
+                        border: '1px solid var(--joplin-color-error, #d9534f)',
+                        boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+                    }}
+                >
+                    ⚠️ Not updating
+                </div>
+            )}
         </div>
     );
 };

--- a/src/gui/react/components/WikiView.tsx
+++ b/src/gui/react/components/WikiView.tsx
@@ -250,7 +250,7 @@ const WikiView: React.FC<WikiViewProps> = ({ projectId, onOpenNote, lastUpdated,
             if (wikiData.length === 0) setLoading(true);
             try {
                 const data = await window.webviewApi.postMessage({ name: 'getWikiData', payload: { projectId } });
-                if (mounted) setWikiData(data);
+                if (mounted && data) setWikiData(data);
             } catch (e) {
                 console.error("Error loading wiki", e);
             } finally { if (mounted) setLoading(false); }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 1,
 	"id": "com.scrayil.joplin-plugin-projects",
 	"app_min_version": "3.4.12",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"name": "Projects",
 	"description": "Easily manage and schedule projects, integrating tasks directly with your knowledge base.",
 	"author": "Mattia Bennati (Scrayil)",

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -119,9 +119,10 @@ export class ProjectService {
         const tagsMap = await this.tagService.getTagsForNotes(noteIds);
 
         let tagsSignature = '';
-        tagsMap.forEach((tags, id) => {
-            tagsSignature += `${id}:${tags.sort().join(',')}|`;
-        });
+        for (const id of noteIds) {
+            const tags = tagsMap.get(id);
+            if (tags) tagsSignature += `${id}:${tags.sort().join(',')}|`;
+        }
 
         let maxProjectUpdated = 0;
         let projectsIdStr = '';
@@ -206,18 +207,19 @@ export class ProjectService {
             });
         }
 
+        const pollingInterval = Number(await getSettingValue(Config.SETTINGS.PROJECT_POLLING_INTERVAL)) || 3000;
         const data = {
             projects: projectFolders
                 .sort((a, b) => sanitizeTitle(a.title).localeCompare(sanitizeTitle(b.title), undefined, { sensitivity: 'accent' }))
                 .map((p: any) => ({ id: p.id, name: p.title })),
             tasks: dashboardTasks,
             config: {
-                pollingInterval: 3000
+                pollingInterval: pollingInterval
             }
         };
         
         this.dashboardCache = data;
-        this.lastSignature = currentSignature + `-${approachingDays}`; // Invalidate on setting change
+        this.lastSignature = currentSignature + `-${approachingDays}-${pollingInterval}`; // Invalidate on setting change
         
         return data;
     }
@@ -468,8 +470,19 @@ export class ProjectService {
         // Only notes carry a body; folders act as headers. Items are shared by
         // reference with flatList, so mutating them here updates the returned list.
         const noteItems = flatList.filter(item => item.type === 'note');
-        const batchSize = 20;
 
+        let resourceMimeCache: Map<string, string>;
+        const getResourceMimes = async (): Promise<Map<string, string>> => {
+            if (!resourceMimeCache) {
+                const all = await fetchAllItems(['resources'], {fields: ['id', 'mime']});
+                resourceMimeCache = new Map<string, string>(
+                    all.map((res: any) => [res.id, res.mime || ''])
+                );
+            }
+            return resourceMimeCache;
+        };
+
+        const batchSize = 20;
         for (let i = 0; i < noteItems.length; i += batchSize) {
             const batch = noteItems.slice(i, i + batchSize);
             await Promise.all(batch.map(async (item) => {
@@ -493,10 +506,7 @@ export class ProjectService {
                         // attached resources are listed first so that note links are never sent
                         // to the resource API, which would otherwise log a "No such resource"
                         // error for every internal note link in the wiki.
-                        const noteResources = await fetchAllItems(['notes', item.id, 'resources'], { fields: ['id', 'mime'] });
-                        const mimeByResourceId = new Map<string, string>(
-                            noteResources.map((res: any) => [res.id, res.mime || ''])
-                        );
+                        const mimeByResourceId = await getResourceMimes();
 
                         await Promise.all(uniqueIds.map(async (id) => {
                             // IDs absent from the note's resource set are internal note links and

--- a/src/services/TagService.ts
+++ b/src/services/TagService.ts
@@ -87,42 +87,31 @@ export class TagService {
     }
 
     /**
-     * Retrieves the tag titles associated with each of the given notes, processing
-     * them in fixed-size batches. Notes whose tag lookup fails are omitted from the
-     * result.
+     * Retrieves the tag titles associated with each of the given notes.
+     *
+     * The query is inverted: one request per tag rather than one per note because the Data API exposes no bulk
+     * note-to-tag endpoint, and this runs on every dashboard refresh.
+     * Collections have far fewer tags than notes, so the inversion is typically way cheaper. It is only worse for a
+     * collection holding more tags than notes. See the GitHub #46 and #47 issues for the regression linked to this.
+     *
      * @param noteIds The IDs of the notes whose tags are retrieved.
-     * @returns A map from note ID to its array of tag titles.
+     * @returns A map from note ID to its array of tag titles. Notes with no tags are excluded from the map.
      */
     public async getTagsForNotes(noteIds: string[]): Promise<Map<string, string[]>> {
-        const noteTagsMap = new Map<string, string[]>();
-        const batchSize = 10;
-        
-        for (let i = 0; i < noteIds.length; i += batchSize) {
-            const batch = noteIds.slice(i, i + batchSize);
-            const promises = batch.map(id => this.fetchTagsForNote(id));
-            
-            const results = await Promise.allSettled(promises);
-            
-            results.forEach(result => {
-                if (result.status === 'fulfilled') {
-                    const { id, tags } = result.value;
-                    noteTagsMap.set(id, tags);
-                }
-            });
-        }
-        
-        return noteTagsMap;
-    }
+        const wanted = new Set(noteIds);
+        const map = new Map<string, string[]>();
+        const tags = await fetchAllItems(['tags'], { fields: ['id', 'title'] });
 
-    /**
-     * Helper to fetch tags for a single note.
-     */
-    private async fetchTagsForNote(noteId: string): Promise<{ id: string, tags: string[] }> {
-        const tags = await fetchAllItems(['notes', noteId, 'tags'], { fields: ['title'] });
-        return {
-            id: noteId,
-            tags: tags.map((t: any) => t.title)
-        };
+        for (const tag of tags) {
+            const tagged = await fetchAllItems(['tags', tag.id, 'notes'], { fields: ['id']});
+            for (const note of tagged) {
+                if (!wanted.has(note.id)) continue;
+                const list = map.get(note.id) ?? [];
+                list.push(tag.title);
+                map.set(note.id, list);
+            }
+        }
+        return map;
     }
 
     /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,8 +10,9 @@ export const Config = {
 
     SETTINGS: {
         PROJECT_SECTION: PREFIX + 'settings_section',
-        PROJECT_WIKI_TEMPLATE: PREFIX + 'new_project_wiki_template_setting',
         PROJECT_APPROACHING_DEADLINE: PREFIX + 'approaching_deadline_days',
+        PROJECT_POLLING_INTERVAL: PREFIX + 'polling_interval_ms',
+        PROJECT_WIKI_TEMPLATE: PREFIX + 'new_project_wiki_template_setting',
     },
 
     MENUS: {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -13,16 +13,6 @@ export const registerSettings = async () => {
     });
 
     await joplin.settings.registerSettings({
-        [Config.SETTINGS.PROJECT_WIKI_TEMPLATE]: {
-            value: '',
-            type: SettingItemType.String,
-            subType: SettingItemSubType.FilePath,
-            section: Config.SETTINGS.PROJECT_SECTION,
-            public: true,
-            label: "Project Wiki template structure (.json)",
-            description: "Select the .json file that defines the custom folder structure for new project wikis. Leave empty for default.",
-            advanced: true
-        },
         [Config.SETTINGS.PROJECT_APPROACHING_DEADLINE]: {
             value: 7,
             type: SettingItemType.Int,
@@ -32,6 +22,28 @@ export const registerSettings = async () => {
             public: true,
             label: "Approaching deadline warning (days)",
             description: "Tasks due within this number of days will be highlighted in orange."
+        },
+        [Config.SETTINGS.PROJECT_POLLING_INTERVAL]: {
+            value: 3000,
+            type: SettingItemType.Int,
+            minimum: 1000,
+            maximum: 60000,
+            step: 1000,
+            section: Config.SETTINGS.PROJECT_SECTION,
+            public: true,
+            label: "Dashboard refresh interval (ms)",
+            description: "How often the dashboard polls for changes made outside the plugin. Raise on very large collections.",
+            advanced: true,
+        },
+        [Config.SETTINGS.PROJECT_WIKI_TEMPLATE]: {
+            value: '',
+            type: SettingItemType.String,
+            subType: SettingItemSubType.FilePath,
+            section: Config.SETTINGS.PROJECT_SECTION,
+            public: true,
+            label: "Project Wiki template structure (.json)",
+            description: "Select the .json file that defines the custom folder structure for new project wikis. Leave empty for default.",
+            advanced: true
         }
     });
 


### PR DESCRIPTION
## Summary

Investigating the slowdowns reported in #46 and #47 turned up an N+1 in the dashboard refresh path: `TagService.getTagsForNotes` issued one Data API call per to-do note, and because the result feeds the cache signature, it ran on **every** refresh, cache hit or miss.

On a collection resembling the one in #47 (~200 todos, ~12 project folders, ~10 tags) that is roughly **213 API calls every 3 seconds**, all served by the same SQLite connection that `ResourceService`, `SearchEngine` and `RevisionService` use. Those three services are what the reporters see in their logs: they are not slow, they are waiting.

After this change the same refresh costs **~23 calls**.

## What changed

**`perf(dashboard)`**: the tag query is inverted to one request per tag rather than per note, the wiki resource index is fetched once per load instead of once per note and selecting a different note no longer invalidates the dashboard cache, since the content signature already covers every change that matters. The refresh interval becomes a setting, still defaulting to 3 seconds.

**`fix(dashboard)`**: a failed refresh would have arrived as an empty value and  would have replaced the dashboard state, crashing the panel. The response is now validated, previous content is kept, and an indicator appears after three consecutive failures. The wiki had the same defect and gets the same guard.

**`chore`**: version bump and changelog.

## What this does *not* claim

**It is not confirmed to fix #46 or #47.** Neither reporter's environment reproduces here: a Windows 11 VM with a comparable dataset (362 notes, 223 resources, 8 projects) stays at 100-200 ms throughout, and a deliberate load test with 100 extra tags, pushing the pre-fix call volume back to ~113 per cycle also stayed flat. That machine is simply too fast to reach the pathological point.

The commits therefore reference the issues rather than closing them. They will be closed when a reporter confirms, not on merge.

## Testing

Full functional pass on the Windows VM: tag rendering and priority sorting, cache invalidation on external tag changes, note selection, task creation/deletion/move, project rename and deletion, wiki rendering including inline media and note links, theme switching, the new setting, and dependency cascading in the timeline.  
Type check and build clean.

One pre-existing defect surfaced and is **not** addressed here: PDFs opened from the wiki navigate the panel away with no way back, because only audio and video are intercepted. Separate issue.

Refs: #46, #47